### PR TITLE
Do not define PB_DEBUG by default & Added PB_DBG_DUMB(...) definition when PB_DEBUG is not defined

### DIFF
--- a/src/PageBuilder.h
+++ b/src/PageBuilder.h
@@ -31,7 +31,7 @@ using WebServerClass = WebServer;
 #endif
 
 // Uncomment the following PB_DEBUG to enable debug output.
-#define PB_DEBUG
+// #define PB_DEBUG
 
 // Debug output destination can be defined externally with PB_DEBUG_PORT
 #ifndef PB_DEBUG_PORT
@@ -41,6 +41,7 @@ using WebServerClass = WebServer;
 #define PB_DBG_DUMB(...) do {PB_DEBUG_PORT.printf( __VA_ARGS__ );} while (0)
 #define PB_DBG(...) do {PB_DEBUG_PORT.print("[PB] "); PB_DEBUG_PORT.printf( __VA_ARGS__ );} while (0)
 #else
+#define PB_DBG_DUMB(...)
 #define PB_DBG(...)
 #endif // !PB_DEBUG
 


### PR DESCRIPTION
Because PB_DEBUG is on by default, there is no easy way to switch it of when installed via Arduino IDE or Platform.IO. While we can add a define to the setup if we want to switch it on.

(Also the PB_DBG_DUMB definition was missing if PB_DEBUG is undefined.

