### PR TITLE
fix error when one URL is called twice consecutively

### DIFF
--- a/examples/DynamicPage/DynamicPage.ino
+++ b/examples/DynamicPage/DynamicPage.ino
@@ -78,6 +78,7 @@ bool handleAcs(HTTPMethod method, String uri) {
     else {
       return false;    // Not found to accessing exception URI.
     }
+    currentUri = String("");
   }
 }
 


### PR DESCRIPTION
In the exampe `DynamicPage.ino`, in the method `handleAcs` `currentUri` is set to the parameter `uri` to check if the method is called the first or second time during a request. However, when one URL is called twice consecutively, `currentUri` is still set to that URL from the previous request. This PR fixes it by resetting `currentUri` to an empty string after every successfull URL handling.