### PR TITLE
Add support for ESP32 Core v3.x

### DIFF
--- a/src/PageBuilder.cpp
+++ b/src/PageBuilder.cpp
@@ -505,6 +505,33 @@ bool PageBuilder::canUpload(PageBuilderUtil::URI_TYPE_SIGNATURE uri) {
   return true;
 }
 
+#if defined(ARDUINO_ARCH_ESP32) && (ESP_ARDUINO_VERSION_MAJOR >= 3)
+/**
+ * Wrapper for ESP32 Arduino Core 3.x new API.
+ * Without this, PageBuilder won't work on such version.
+ * @param   server  Unused.
+ * @param   requestMethod   HTTP method of the current request.
+ * @param   RequestUri  Requested URI
+ * @return  true  the PageBuilder can handle this request.
+ * @return  false
+ */
+bool PageBuilder::canHandle(WebServer &server, HTTPMethod requestMethod, PageBuilderUtil::URI_TYPE_SIGNATURE requestUri) {
+  return canHandle(requestMethod, requestUri);
+}
+
+/**
+ * Wrapper for ESP32 Arduino Core 3.x new API.
+ * Without this, PageBuilder won't work on such version.
+ * @param   server  Unused.
+ * @param   uri Requested uploading URI.
+ * @return  true  The uploader will activate.
+ * @return  false The uploader does not correspond to the requested URI.
+ */
+bool PageBuilder::canUpload(WebServer &server, PageBuilderUtil::URI_TYPE_SIGNATURE uri) {
+  return canUpload(uri);
+}
+#endif
+
 /**
  * Calculates the approximate content size,
  * not including token replacement.

--- a/src/PageBuilder.cpp
+++ b/src/PageBuilder.cpp
@@ -689,7 +689,7 @@ void PageBuilder::_handle(int code, WebServer& server) {
         server.sendContent_P(contentBlock.c_str());
         (void)(blkSize);
         PB_DBG("blk:%u\n", blkSize);
-        server.client().flush();
+        CLIENT_CLEAR(server.client());
       }
     }
     else {
@@ -723,7 +723,7 @@ void PageBuilder::_handle(int code, WebServer& server) {
               bp = cBuffer;
               cBufferLen = PAGEBUILDER_CONTENTBLOCK_SIZE;
             }
-            server.client().flush();
+            CLIENT_CLEAR(server.client());
             blkSize = pe.build(bp, cBufferLen, args);
           }
         }

--- a/src/PageBuilder.h
+++ b/src/PageBuilder.h
@@ -297,11 +297,16 @@ namespace PageBuilderUtil {
   // backward compatibility with ESP8266 arduino core 3.0.0 and later.
   // However, it relies solely on the canHandle member function as a criterion
   // and lacks completeness.
+#if defined(ARDUINO_ARCH_ESP32) && (ESP_ARDUINO_VERSION_MAJOR >= 3)
+#define CLIENT_CLEAR(client) (client.clear())
+  using URI_TYPE_SIGNATURE = const String &;
+#else
+#define CLIENT_CLEAR(client) (client.flush()) // Deprecated starting ESP32 Arduino Core 3.x
   using URI_TYPE_SIGNATURE = std::conditional<
-    std::is_lvalue_reference<TypeOfArgument<decltype(&RequestHandler::canHandle)>::arg<1>::type>::value,
-    const String&,
-    String
-  >::type;
+      std::is_lvalue_reference<TypeOfArgument<decltype(&RequestHandler::canHandle)>::arg<1>::type>::value,
+      const String &,
+      String>::type;
+#endif
 };
 
 /**
@@ -335,6 +340,10 @@ class PageBuilder : public RequestHandler {
   size_t  build(String& content);
   size_t  build(String& content, PageArgument& args);
   void  cancel(const bool cancelation = true) { _cancel = cancelation; }
+#if defined(ARDUINO_ARCH_ESP32) && (ESP_ARDUINO_VERSION_MAJOR >= 3)
+  virtual bool canHandle(WebServer &server, HTTPMethod requestMethod, PageBuilderUtil::URI_TYPE_SIGNATURE requestUri) override;
+  virtual bool canUpload(WebServer &server, PageBuilderUtil::URI_TYPE_SIGNATURE uri) override;
+#endif
   virtual bool  canHandle(HTTPMethod requestMethod, PageBuilderUtil::URI_TYPE_SIGNATURE requestUri) override;
   virtual bool  canUpload(PageBuilderUtil::URI_TYPE_SIGNATURE uri) override;
   void  clearElements(void) { _elements.clear(); }


### PR DESCRIPTION
The ESP32 Arduino Core 3.x based on ESP-IDF 5.x breaks compatibility with the PageBuilder library. These fixes make it possible for the library to compile with Core 3.x versions and it seems to be working properly (tested on ESP32-S3).

- The function flush() from the ESP32 WiFi library has been deprecated. **Use clear() instead**
- The ESP32 Arduino Core 3.x RequestHandler features new API versions for canHandle() and canUpdate() that take in a reference to a WebServer as well. Even if the old APIs are still supported, when the WebServer parses a request it will make use of the new API, therefore bypassing PageBuilder and ending up in the Captive Portal pages not being loaded resulting in an error 404 when trying to browse the /_ac pages. **If on ESP32 Core v3.x or later, define wrappers for canHandle() and canUpdate() using the WebServer& parameter that will just execute the old version of the API.** This is needed only to ensure PageBuilder API isn't bypassed for the RequestHandler API, but in reality, we have no use for the WebServer reference, so we just make a function call for the old API. This ensures compatibility with ESP32 Arduino Core 3.x while mantaining backwards compatibility with older Core versions and ESP8266.